### PR TITLE
fix(until): use correct call signature for processPart

### DIFF
--- a/src/until.ts
+++ b/src/until.ts
@@ -13,12 +13,12 @@ export const until = directive<Array<Promise<unknown>>>(
         Promise.resolve(promises[i]).then(value => {
           if (i < state.i) {
             state.i = i
-            processPart(part, {[part.expression]: value})
+            processPart(part, value)
           }
         })
       } else if (i <= state.i) {
         state.i = i
-        processPart(part, {[part.expression]: promises[i]})
+        processPart(part, promises[i])
       }
     }
   }


### PR DESCRIPTION
This fixes the build, which broke in #2 - perhaps an eager merge. 

The build was failing but this wasn't noticed because GitHub Actions hadn't been set up properly for this repo!!

It is now set up, this branch wont be able to be merged without CI passing :smile: 