### PR TITLE
fix(until): allow non Promise values in type

### DIFF
--- a/src/until.ts
+++ b/src/until.ts
@@ -21,5 +21,3 @@ export const until = directive((...promises: unknown[]) => (part: TemplatePart) 
     }
   }
 })
-
-until(Promise.resolve(true), true)

--- a/src/until.ts
+++ b/src/until.ts
@@ -3,25 +3,23 @@ import {directive} from './directive'
 import type {TemplatePart} from '@github/template-parts'
 
 const untils: WeakMap<TemplatePart, {i: number}> = new WeakMap()
-export const until = directive(
-  (...promises: unknown[]) => (part: TemplatePart) => {
-    if (!untils.has(part)) untils.set(part, {i: promises.length})
-    const state = untils.get(part)!
-    for (let i = 0; i < promises.length; i += 1) {
-      if (promises[i] instanceof Promise) {
-        // eslint-disable-next-line github/no-then
-        Promise.resolve(promises[i]).then(value => {
-          if (i < state.i) {
-            state.i = i
-            processPart(part, value)
-          }
-        })
-      } else if (i <= state.i) {
-        state.i = i
-        processPart(part, promises[i])
-      }
+export const until = directive((...promises: unknown[]) => (part: TemplatePart) => {
+  if (!untils.has(part)) untils.set(part, {i: promises.length})
+  const state = untils.get(part)!
+  for (let i = 0; i < promises.length; i += 1) {
+    if (promises[i] instanceof Promise) {
+      // eslint-disable-next-line github/no-then
+      Promise.resolve(promises[i]).then(value => {
+        if (i < state.i) {
+          state.i = i
+          processPart(part, value)
+        }
+      })
+    } else if (i <= state.i) {
+      state.i = i
+      processPart(part, promises[i])
     }
   }
-)
+})
 
 until(Promise.resolve(true), true)

--- a/src/until.ts
+++ b/src/until.ts
@@ -3,8 +3,8 @@ import {directive} from './directive'
 import type {TemplatePart} from '@github/template-parts'
 
 const untils: WeakMap<TemplatePart, {i: number}> = new WeakMap()
-export const until = directive<Array<Promise<unknown>>>(
-  (...promises: Array<Promise<unknown>>) => (part: TemplatePart) => {
+export const until = directive(
+  (...promises: unknown[]) => (part: TemplatePart) => {
     if (!untils.has(part)) untils.set(part, {i: promises.length})
     const state = untils.get(part)!
     for (let i = 0; i < promises.length; i += 1) {
@@ -23,3 +23,5 @@ export const until = directive<Array<Promise<unknown>>>(
     }
   }
 )
+
+until(Promise.resolve(true), true)


### PR DESCRIPTION
This directive coerces values to Promises using `Promise.resolve` and as such is capable of receiving non-promise values.