### PR TITLE
docs: fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ const p = ({classOne, classTwo, classThree}) => html`<p class="${classOne} ${cla
 render(p({classOne: 'red', classTwo: 'box', classThree: ''}), document.body)
 // ^ Renders `<p class="red box  "></p>`
 
-const i = ({classOne, classTwo}) => html`<p class="${classOne}-${classTwo}"></p>`
+const i = ({classOne, classTwo}) => html`<i class="${classOne}-${classTwo}"></i>`
 
-render(p({classOne: 'red', classTwo: 'box'}), document.body)
+render(i({classOne: 'red', classTwo: 'box'}), document.body)
 // ^ Renders `<i class="red-box"></i>`
 ```
 


### PR DESCRIPTION
Hi,

I think I found a typo in the example below and I fix it

```js
const i = ({classOne, classTwo}) => html`<p class="${classOne}-${classTwo}"></p>`

render(p({classOne: 'red', classTwo: 'box'}), document.body)
// ^ Renders `<i class="red-box"></i>`
```

Let me know if i'm wrong 😅 