### PR TITLE
Include file extension in all imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
   "extends": ["plugin:github/recommended", "plugin:github/typescript", "plugin:github/browser"],
   "rules": {
     "no-invalid-this": "off",
-    "@typescript-eslint/no-invalid-this": ["error"]
+    "@typescript-eslint/no-invalid-this": ["error"],
+    "import/extensions": ["error", "always"]
   },
   "overrides": [
     {

--- a/src/html.ts
+++ b/src/html.ts
@@ -5,8 +5,8 @@ import {
   processPropertyIdentity,
   processBooleanAttribute
 } from '@github/template-parts'
-import {processDirective} from './directive'
-import {processEvent} from './events'
+import {processDirective} from './directive.js'
+import {processEvent} from './events.js'
 import type {TemplatePart, TemplateTypeInit} from '@github/template-parts'
 
 function processSubTemplate(part: TemplatePart, value: unknown): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export {TemplateResult, html, render} from './html'
-export {isDirective, directive} from './directive'
-export {until} from './until'
-export {unsafeHTML} from './unsafe-html'
+export {TemplateResult, html, render} from './html.js'
+export {isDirective, directive} from './directive.js'
+export {until} from './until.js'
+export {unsafeHTML} from './unsafe-html.js'

--- a/src/unsafe-html.ts
+++ b/src/unsafe-html.ts
@@ -1,4 +1,4 @@
-import {directive} from './directive'
+import {directive} from './directive.js'
 import {NodeTemplatePart} from '@github/template-parts'
 import type {TemplatePart} from '@github/template-parts'
 

--- a/src/until.ts
+++ b/src/until.ts
@@ -1,5 +1,5 @@
-import {processPart} from './html'
-import {directive} from './directive'
+import {processPart} from './html.js'
+import {directive} from './directive.js'
 import type {TemplatePart} from '@github/template-parts'
 
 const untils: WeakMap<TemplatePart, {i: number}> = new WeakMap()

--- a/test/html.ts
+++ b/test/html.ts
@@ -1,4 +1,4 @@
-import {html, render, directive} from '..'
+import {html, render, directive} from '../lib/index.js'
 
 describe('html', () => {
   it('creates new TemplateResults with each call', () => {

--- a/test/unsafe-html.ts
+++ b/test/unsafe-html.ts
@@ -1,4 +1,4 @@
-import {html, render, unsafeHTML} from '..'
+import {html, render, unsafeHTML} from '../lib/index.js'
 
 describe('unsafeHTML', () => {
   it('renders basic text', async () => {

--- a/test/until.ts
+++ b/test/until.ts
@@ -1,4 +1,4 @@
-import {html, render, until} from '..'
+import {html, render, until} from '../lib/index.js'
 
 describe('until', () => {
   it('renders a Promise when it resolves', async () => {


### PR DESCRIPTION
Because this package is `"type": "module"`, node (and bundlers) will interpret it as ESM and expect file extensions to be included for all relative imports.  Our other projects haven't had a huge issue with this because Rollup tends to glaze over it, but we should add these extensions to be ESM compatible.